### PR TITLE
Restore vehicle metadata fields and capture client IP

### DIFF
--- a/apps_script/Código.gs
+++ b/apps_script/Código.gs
@@ -1,5 +1,5 @@
 /** ===== CONFIG ===== **/
-const SHEET_ID     = '1N-T6z_FH2EizaW3WOE6Pnr7tpASiIMTaHewc1N2ozTI';
+const SHEET_ID     = '14sYnGGtCufCsZPxJVXGznurB3zL4cbyFWLE6wcPTA54';
 const SHEET_NAME   = 'Publico';
 const PROTO_PREFIX = 'TOP-';
 const COLS = [
@@ -15,7 +15,7 @@ function doPost(e) {
     }
     const d = JSON.parse(e.postData.contents);
     const proto = PROTO_PREFIX + Date.now();
-    const ip = e?.context?.clientIp || e?.parameter?.ip || 'N/A';
+    const ip = d.ip || e?.context?.clientIp || e?.parameter?.ip || 'IP_NAO_DETECTADO';
     const sh = _sheet();
     const anexosStr = Array.isArray(d.anexos) ? d.anexos.join(' ') : (d.anexos || '');
     const row = [


### PR DESCRIPTION
## Summary
- reintroduce the sentido, tipo de veículo e tipo de serviço campos no formulário NovaReclamacao para alimentar as colunas da planilha
- buscar o IP público do usuário e enviá-lo junto com a confirmação da LGPD ao Apps Script
- ajustar o Apps Script para priorizar o IP enviado no corpo e manter fallback controlado

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb3ba0d46483209da0bf66fb8d1fd5